### PR TITLE
chore: trigger community-docs-release postsubmit

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -83,3 +83,4 @@ Prow job that runs whenever a new tag of any controller is published, or if any
 part of the documentation is updated.
 
 [View the status of Prow jobs.](https://prow.ack.aws.dev/?job=*-docs-release)
+


### PR DESCRIPTION
Trivial change to docs/ to trigger community-docs-release postsubmit.